### PR TITLE
Hide IT in profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,5 +118,30 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>skip-it</id>
+			<activation>
+				<property>
+					<name>!run-it</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<configuration>
+							<excludes>
+								<exclude>**/MATLABIT.*</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
This enables building the repo without a MATLAB installation.